### PR TITLE
Read CO name from the workspace info file

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,7 @@ Github pages
 
 [![GitHub Actions Push](https://github.com/chStaiger/ansible_test_rsc/actions/workflows/github-actions-demo.yml/badge.svg)](https://github.com/chStaiger/ansible_test_rsc/actions/workflows/github-actions-demo.yml)
 [![CI](https://github.com/chStaiger/ansible_test_rsc/actions/workflows/blank.yml/badge.svg)](https://github.com/chStaiger/ansible_test_rsc/actions/workflows/blank.yml)
+
+# running rapid7 install
+
+`ansible-playbook -b -c ssh -i ip, -uusername playbooks/rapid7.yml`

--- a/playbooks/rapid7.yml
+++ b/playbooks/rapid7.yml
@@ -6,8 +6,5 @@
   vars_prompt:
     - name: token
       prompt: Enter token
-    - name: co_name
-      prompt: Enter CO name
-      private: false
   roles:
     - rapid7

--- a/playbooks/roles/rapid7/tasks/main.yml
+++ b/playbooks/roles/rapid7/tasks/main.yml
@@ -18,6 +18,11 @@
   register: workspace_name
   changed_when: false
 
+- name: Get CO name
+  ansible.builtin.shell: jq -r .co_name < /etc/rsc/workspace.json
+  register: co_name
+  changed_when: false
+
 - name: Debug
   debug:
      var: workspace_name

--- a/playbooks/roles/rapid7/tasks/main.yml
+++ b/playbooks/roles/rapid7/tasks/main.yml
@@ -29,15 +29,11 @@
 
 - name: Set attributes
   ansible.builtin.set_fact:
-    attributes: "{{ ['SurfResearchCloud', co_name, workspace_name.stdout] | map('regex_replace', '[^A-Za-z0-9_\\-=]', '') | list | join(',') }}"
+    attributes: "{{ ['SurfResearchCloud', co_name.stdout, workspace_name.stdout] | map('regex_replace', '[^A-Za-z0-9_\\-=]', '') | list | join(',') }}"
 
 - name: Debug
   debug:
     var: attributes
-
-- name: Debug
-  debug:
-     var: token
 
 - name: Install rapid7
   command: ./agent_installer-x86_64.sh install_start --token {{token}} --attributes "{{ attributes }}"


### PR DESCRIPTION
SURF has added `co_name` to `/etc/rsc/workspace.json`, so no longer any need to prompt the user for this info.